### PR TITLE
I needed to get more data into the tooltip

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -15,7 +15,7 @@
 	var options = {
 		tooltip: false, //boolean
 		tooltipOpts: {
-			content: "%s | X: %x | Y: %y.2", //%s -> series label, %x -> X value, %y -> Y value, %x.2 -> precision of X value, %p -> percent
+			content: "%s | X: %x | Y: %y.2 | Extra: %data[2]", //%s -> series label, %x -> X value, %y -> Y value, %x.2 -> precision of X value, %p -> percent, %data[2] -> raw data from third element of point (extra labels)
 			dateFormat: "%y-%0m-%0d",
 			shifts: {
 				x: 10,
@@ -106,6 +106,7 @@
 			var seriesPattern = /%s/;
 			var xPattern = /%x\.{0,1}(\d{0,})/;
 			var yPattern = /%y\.{0,1}(\d{0,})/;
+			var dataPattern = /%data\[(\d)\]/g;
 			
 			//percent match
 			if( typeof (item.series.percent) !== 'undefined' ) {
@@ -126,6 +127,9 @@
 			if( typeof item.series.data[item.dataIndex][1] === 'number' ) {
 				content = adjustValPrecision(yPattern, content, item.series.data[item.dataIndex][1]);
 			}
+			
+			// additional data fields
+            		content = content.replace(dataPattern, function(match, index) { return item.series.data[item.dataIndex][index] });
 
 			return content;
 		};


### PR DESCRIPTION
So I added the ability to pull arbitrary data stored in the series data by using a new pattern: '%data[index]'.  This way I can put as many additional bits of information as I want (flot ignores everything after the first two) to make the tooltips look a little nicer.  I'm actively using this right now for an internal company tool and it is working great but there may be some edge cases related to other plugins that I am not accounting for.
