### PR TITLE
Touch devices will always display the tooltip at the previous touch position, not the current one

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -65,6 +65,8 @@
             
             // bind event
             $( plot.getPlaceholder() ).bind("plothover", function (event, pos, item) {
+                that.updateTooltipPosition({ x: pos.pageX, y: pos.pageY });
+                
                 if (item) {                    
                     var tipText;
                     


### PR DESCRIPTION
Since touch devices don't fire mousemove events. Fix simply calls updateTooltipPosition while we're handling plothover.

Tested on iPad iOS6. Android 2.0.3 doesn't display tooltip in the first place (no change in behaviour)
