### PR TITLE
Properly fix tooltip x/y with respect to current viewport

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -60,9 +60,9 @@
                     // convert tooltip content template to real tipText
                     tipText = that.stringFormat(that.tooltipOptions.content, item);
 
+                    $tip.html( tipText );
                     that.updateTooltipPosition({ x: pos.pageX, y: pos.pageY });
-                    $tip.html( tipText )
-                        .css({
+                    $tip.css({
                             left: that.tipPosition.x + that.tooltipOptions.shifts.x,
                             top: that.tipPosition.y + that.tooltipOptions.shifts.y
                         })
@@ -120,8 +120,8 @@
 
     // as the name says
     FlotTooltip.prototype.updateTooltipPosition = function(pos) {
-        var totalTipWidth = $("#flotTip").width() + 3 * this.tooltipOptions.shifts.x;
-        var totalTipHeight = $("#flotTip").height() + 2 * this.tooltipOptions.shifts.y;
+        var totalTipWidth = $("#flotTip").outerWidth() + this.tooltipOptions.shifts.x;
+        var totalTipHeight = $("#flotTip").outerHeight() + this.tooltipOptions.shifts.y;
         if ((pos.x - $(window).scrollLeft()) > ($(window).innerWidth() - totalTipWidth)) {
             pos.x -= totalTipWidth;
         }


### PR DESCRIPTION
A more complete version of the tooltip position fixups.  It fixes both x and y co-ordinates now, and does this with respect to the current viewport, so a large page that's scrolled down to see the graph(s) will still work.

Hopefully I got the pull request all correct this time :).

NB: This is still somewhat of a heuristic.
What I'd like to do is something like:

var totalTipWidth = $("#flotTip").width() + this.tooltipOptions.shifts.x + $("#flotTip").css('padding-left') + $("#flotTip").css('padding-right') + $("#flotTip").css('border-left-width') + $("#flotTip").css('border-right-width');

But the .css() properties don't seem to be set at this point (they
return NaN).  So instead there's the heuristic of using multiples of the
shifts.x/y instead.

The change in the call to that.updateTooltipPosition() is from:

https://github.com/Cu3bluKekc/flot.tooltip/commit/f0b6b859dadedad64a08e178b825dce0089a5c0c

who first prompted me to look at the y fixup as well.
