### PR TITLE
Avoid an empty tooltip showing up right after body loading.

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -120,7 +120,7 @@
                     'border-radius': '0.5em',
                     'font-size': '0.8em',
                     'border': '1px solid #111',
-                    'display': 'inline-block',
+                    'display': 'none',
                     'white-space': 'nowrap'
                 });
             }


### PR DESCRIPTION
fixes issue #44
