### PR TITLE
Force conversion to numeric, to prevent invalid date if tmst is string

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -211,7 +211,7 @@
 
     //
     FlotTooltip.prototype.timestampToDate = function(tmst, dateFormat) {
-        var theDate = new Date(tmst);
+	var theDate = new Date(tmst*1);
         return $.plot.formatDate(theDate, dateFormat);
     };
 


### PR DESCRIPTION
Just a quick fix since my underlying data was in string format, flot does not care, this plugin just cannot format the x axis since it is trying to instanmtiate a date with a string which is not valid
