### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "flot.tooltip",
+  "version": "0.6.7",
+  "main": "js/jquery.flot.tooltip.js",
+  "ignore": [
+    ".gitignore",
+    "Gruntfile.js",
+    "README.md",
+    "package.json",
+    "examples",
+    "js/old"
+  ]
+}


### PR DESCRIPTION
Merging this commit and adding a tag named "0.6.7" is all that's needed for flot.tooltip to be installable via bower!
