### PR TITLE
Numeric tooltips on X are incorrect on horizontal charts

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -297,8 +297,12 @@ if (!Array.prototype.indexOf) {
             // see https://github.com/krzysu/flot.tooltip/issues/65
             var tickIndex = item.dataIndex + item.seriesIndex;
 
-            if(item.series.xaxis[ticks].length > tickIndex && !this.isTimeMode('xaxis', item))
-                content = content.replace(xPattern, item.series.xaxis[ticks][tickIndex].label);
+            if(item.series.xaxis[ticks].length > tickIndex && !this.isTimeMode('xaxis', item)) {
+                var value = (this.isCategoriesMode('xaxis', item)) ? item.series.xaxis[ticks][tickIndex].label : item.series.xaxis[ticks][tickIndex].v;
+                if (value === x) {
+                    content = content.replace(xPattern, item.series.xaxis[ticks][tickIndex].label);
+                }
+            }
         }
 
         // change y from number to given label, if given


### PR DESCRIPTION
The problem I'm seeing is that the X numeric tooltips on horizontal charts are incorrect, as in:

![horizontal-bars-tooltip-bug](https://cloud.githubusercontent.com/assets/76945/3141778/cb180b26-e999-11e3-8116-c9d1c66d9490.gif)

I expected Series 1's X to be 5, and Series 2's X to be 10. The code is:

``` javascript
var values1 = [ [5.34, 2010] ];
var values2 = [ [10.12, 2015] ];

var options = {
  // Set up bars, horizontal equals true, etc. Nothing special.
};

var plotObj = $.plot( $("#bars"),
  [
      { data: values1, label: "Series 1"},
      { data: values2, label: "Series 2"}      
  ],
  options );
```

If I use the same data, with the same options, just changing `horizontal = false` and changing the data accordingly (x becomes y, and y becomes x), I get the correct values, as in:

![vertical-bars-tooltip-bug](https://cloud.githubusercontent.com/assets/76945/3141787/6621555a-e99a-11e3-82df-d83eb962c8f2.gif)

There's a fiddle showing the problem at http://jsfiddle.net/vitorbaptista/WZ5y7/4/
