### PR TITLE
Add "id" to tooltip element

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -43,6 +43,7 @@ if (!Array.prototype.indexOf) {
     var defaultOptions = {
         tooltip: false,
         tooltipOpts: {
+            id: "flotTip",
             content: "%s | X: %x | Y: %y",
             // allowed templates are:
             // %s -> series label,
@@ -155,10 +156,10 @@ if (!Array.prototype.indexOf) {
      * @return jQuery object
      */
     FlotTooltip.prototype.getDomElement = function() {
-        var $tip = $('#flotTip');
+        var $tip = $('#'+this.tooltipOptions.id);
 
         if( $tip.length === 0 ){
-            $tip = $('<div />').attr('id', 'flotTip');
+            $tip = $('<div />').attr('id', this.tooltipOptions.id);
             $tip.appendTo('body').hide().css({position: 'absolute'});
 
             if(this.tooltipOptions.defaultTheme) {
@@ -180,7 +181,7 @@ if (!Array.prototype.indexOf) {
 
     // as the name says
     FlotTooltip.prototype.updateTooltipPosition = function(pos) {
-        var $tip = $('#flotTip');
+        var $tip = $('#'+this.tooltipOptions.id);
 
         var totalTipWidth = $tip.outerWidth() + this.tooltipOptions.shifts.x;
         var totalTipHeight = $tip.outerHeight() + this.tooltipOptions.shifts.y;


### PR DESCRIPTION
Was added a optional "id" in tooltip element. This model made possible to have and manipulate many tooltips in same document.
