### PR TITLE
Add CSS class to tooltip

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -4,6 +4,7 @@
         tooltip: {
 			show: false,
             id: "flotTip",
+            cssClass: "flotTip",
             content: "%s | X: %x | Y: %y",
             // allowed templates are:
             // %s -> series label,
@@ -244,7 +245,7 @@
         var $tip = $('#' + this.tooltipOptions.id);
 
         if( $tip.length === 0 ){
-            $tip = $('<div />').attr('id', this.tooltipOptions.id);
+            $tip = $('<div />').attr('id', this.tooltipOptions.id).addClass(this.tooltipOptions.cssClass);
             $tip.appendTo('body').hide().css({position: 'absolute'});
 
             if(this.tooltipOptions.defaultTheme) {


### PR DESCRIPTION
When try to add a css selector by ID on ````#flotTip```` CSS lint throws an error:

````Don't use IDs in selectors. Selectors should not contain IDs. (ids)````

Adding a cssClass property to solve this