### PR TITLE
added license information to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "flot.tooltip",
   "version": "0.7.1",
+  "license": "MIT",
   "main": "js/jquery.flot.tooltip.js",
   "ignore": [
     ".gitignore",


### PR DESCRIPTION
We had problems getting any license information out the `flot.tooltip`package by using [bower-license](https://github.com/AceMetrix/bower-license) because neither `README.md` nor `package.json` are delivered by bower.

I simply added license information to `bower.json` to fix this.
