### PR TITLE
add index.html file to examples/ directory

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,28 @@
+<!doctype html>  
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    <title>flot.tooltip plugin example page</title>
+    <meta name="author" content="@kenirwin">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body>
+    <h1>Flot Tooltip Examples</h1>
+
+    <li><a href="custom-label-text.html">Custom Label Text</a></li>
+    <li><a href="custom_ticks.html">Custom Ticks</a></li>
+    <li><a href="dollar_in_tickformatter.html">Dollar in tickFormatter</a></li>
+    <li><a href="many_series.html">Many Series</a></li>
+    <li><a href="multiple-axes.html">Multiple Axes</a></li>
+    <li><a href="pie.html">Pie</a></li>
+    <li><a href="real_data.html">Real-time Data</a></li>
+    <li><a href="stacking.html">Stacking</a></li>
+    <li><a href="threshold.html">Threshold</a></li>
+    <li><a href="time_bars.html">Time Bars</a></li>
+    <li><a href="two_chars.html">Two Charts</a></li>
+</body>
+</html>


### PR DESCRIPTION
I'd like to add an index.html file to the examples directory -- this will be advantageous to anyone who has their servers set up to not automatically generate index pages where none exist. It also parallels the structure of the examples directory of the main flot project: https://github.com/flot/flot/blob/master/examples/index.html 

### Screenshot:

![flot-tooltip-example-index](https://cloud.githubusercontent.com/assets/1894561/7962764/3498ed54-09dd-11e5-914c-f50699fd1ebf.PNG)
