### PR TITLE
improved tooltip formatting for better visibility on time_bars example

### DIFF
--- a/examples/time_bars.html
+++ b/examples/time_bars.html
@@ -37,7 +37,7 @@
 			colors: ["#111"],
 			tooltip: {
 				show: true,
-				content: "<h4>%s</h4><ul><li>X is %x</li><li>Y is %y</li></ul>",
+				content: '<div style="background-color: rgba(255,255,255,0.75); border: 1px solid #000; padding: .25em"><h4 style>%s</h4><ul><li>X is %x</li><li>Y is %y</li></ul></div>',
 				xDateFormat: "%y-%0m-%0d %H:%M:%S",
 				shifts: {
 					x: 10,


### PR DESCRIPTION
The original version of this example had black text in the tooltip hovering over dark grey content in the chart. I've added a bit of styling including a translucent background to the tooltip so that it's more visible.