### PR TITLE
Added examples/basic.html

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -28,7 +28,6 @@
         points: { show: true }
       },
       grid:  { hoverable: true }, //important! flot.tooltip requires this
-      legend: { show: false },
       tooltip: true,
       tooltipOpts: {
         content: "%s | x: %x; y: %y"

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,0 +1,46 @@
+<!doctype html>  
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    <title>flot.tooltip plugin example page</title>
+    <meta name="author" content="@kenirwin">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="http://code.jquery.com/jquery-1.8.3.min.js"></script>
+    <script src="../js/jquery.flot.js"></script>
+    <script src="../js/jquery.flot.tooltip.js"></script>
+
+</head>
+
+<body>
+    <h1>Flot Tooltip Basic Example</h1>
+
+<div id="chart" style="width:600px;height:150px;"></div>
+
+<script>
+  
+  $(function () {
+    var chartOptions = {
+      series: {
+        lines: { show: true },
+        points: { show: true }
+      },
+      grid:  { hoverable: true }, //important! flot.tooltip requires this
+      legend: { show: false },
+      tooltip: true,
+      tooltipOpts: {
+        content: "%s | x: %x; y: %y"
+      }
+    };
+    var chartData = { label: "Sample Data", data: [
+        [1,6],
+        [2,3],
+        [3,9],
+        [4,4],
+        [5,2]
+    ]};
+    $.plot($("#chart"), [chartData], chartOptions);
+  });
+</script>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -9,7 +9,7 @@
     <meta name="author" content="@kenirwin">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="http://code.jquery.com/jquery-1.8.3.min.js"></script>
-    <script src="../js/jquery.flot.js"></script>
+    <script src="js/jquery.flot.js"></script>
     <script src="../js/jquery.flot.tooltip.js"></script>
 
 </head>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,7 @@
 <body>
     <h1>Flot Tooltip Examples</h1>
 
+    <li><a href="basic.html">Basic Configuration</a></li>
     <li><a href="custom-label-text.html">Custom Label Text</a></li>
     <li><a href="custom_ticks.html">Custom Ticks</a></li>
     <li><a href="dollar_in_tickformatter.html">Dollar in tickFormatter</a></li>


### PR DESCRIPTION
Add a basic.html page to the examples directory (and index page) to show the very most basic implementation of the tooltip plugin.