### PR TITLE
use correct .flotTip instead of #flotTip in css of example/pie.html

### DIFF
--- a/examples/pie.html
+++ b/examples/pie.html
@@ -18,7 +18,7 @@
   <style type="text/css">
     body {font-family: sans-serif; font-size: 16px; margin: 50px; max-width: 800px;}
     h4, ul {margin: 0;}
-    #flotTip 
+    .flotTip 
     {
       padding: 3px 5px;
       background-color: #000;


### PR DESCRIPTION
the previous version of this file had a stylesheet entry for the tooltip based on the id rather than the class. I've changed the stylesheet to call the class as is needed to make the styling take effect.