### PR TITLE
updated basic and two_chars examples to use newer option formatting

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -29,7 +29,7 @@
       },
       grid:  { hoverable: true }, //important! flot.tooltip requires this
       tooltip: {
-        show: true
+        show: true,
         content: "%s | x: %x; y: %y"
       }
     };

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -28,8 +28,8 @@
         points: { show: true }
       },
       grid:  { hoverable: true }, //important! flot.tooltip requires this
-      tooltip: true,
-      tooltipOpts: {
+      tooltip: {
+        show: true
         content: "%s | x: %x; y: %y"
       }
     };

--- a/examples/two_chars.html
+++ b/examples/two_chars.html
@@ -20,8 +20,8 @@
       xaxis: { mode: "time", timeformat: "%m/%d", minTickSize: [1, "day"] },
       grid:  { hoverable: true },
       legend: { show: false },
-      tooltip: true,
-      tooltipOpts: {
+      tooltip: {
+        show: true
         content: "y: %y"
       }
     };

--- a/examples/two_chars.html
+++ b/examples/two_chars.html
@@ -21,7 +21,7 @@
       grid:  { hoverable: true },
       legend: { show: false },
       tooltip: {
-        show: true
+        show: true,
         content: "y: %y"
       }
     };


### PR DESCRIPTION
basic.html and two_chars.html were still configured to use the separate tooltip and tooltipOpts configurations. This pull request updates them to the newer format. 