### PR TITLE
Updated package.json - Added entry point for npm / browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "directories": {
     "example": "examples"
   },
+  "main": "./js/jquery.flot.tooltip.js",
+  "browser": "./js/jquery.flot.tooltip.js",
   "dependencies": {},
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
package.json needs to have a "main" and/or "browser" field specifying the main entry point for use in npm with browserify.