### PR TITLE
Remove Tooltip element from DOM on shutdown

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -102,6 +102,7 @@
         plot.hooks.shutdown.push(function (plot, eventHolder){
             $(plot.getPlaceholder()).unbind("plothover", plothover);
             $(plot.getPlaceholder()).unbind("plotclick", plotclick);
+            plot.removeTooltip();
             $(eventHolder).unbind("mousemove", mouseMove);
         });
 
@@ -302,6 +303,10 @@
         // Quick little function for hiding the tooltip.
         plot.hideTooltip = function () {
             that.getDomElement().hide().html('');
+        };
+
+        plot.removeTooltip = function() {
+            that.getDomElement().remove();
         };
     };
 


### PR DESCRIPTION
Not removing the tooltip in the shutdown hook is normally not a big
deal, but creates issues in single-page applications: if the user
navigates away while a tooltip is displayed, the tooltip stays visible
on the page until a hard reload, and that's really awkward.