### PR TITLE
Escape dollar when replacing values for tick's label

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -491,7 +491,7 @@
                 if (item.series.xaxis[ticks].hasOwnProperty(tickIndex) && !this.isTimeMode('xaxis', item)) {
                     var valueX = (this.isCategoriesMode('xaxis', item)) ? item.series.xaxis[ticks][tickIndex].label : item.series.xaxis[ticks][tickIndex].v;
                     if (valueX === x) {
-                        content = content.replace(xPattern, item.series.xaxis[ticks][tickIndex].label);
+                        content = content.replace(xPattern, item.series.xaxis[ticks][tickIndex].label.replace(/\$/g, '$$$$'));
                     }
                 }
             }
@@ -503,7 +503,7 @@
                 if (item.series.yaxis.ticks.hasOwnProperty(yIndex)) {
                     var valueY = (this.isCategoriesMode('yaxis', item)) ? item.series.yaxis.ticks[yIndex].label : item.series.yaxis.ticks[yIndex].v;
                     if (valueY === y) {
-                        content = content.replace(yPattern, item.series.yaxis.ticks[yIndex].label);
+                        content = content.replace(yPattern, item.series.yaxis.ticks[yIndex].label.replace(/\$/g, '$$$$'));
                     }
                 }
             }


### PR DESCRIPTION
I just found that when a tooltip, beginning with `$1`, is placed exactly on a tick with the same value the `$1` is removed due the [`$` behaviour on `String#replace`](http://devdocs.io/javascript/global_objects/string/replace)
> From `String#replace` docs:
> $n or $nn: Where n or nn are decimal digits, inserts the nth parenthesized submatch string, provided the first argument was a RegExp object.

It's easier to visualize this with this example:
![flot-tooltip](https://cloud.githubusercontent.com/assets/157134/12590817/ea811b5e-c44b-11e5-9937-df0fd7056936.png)
Example here: https://jsbin.com/muvakuxefu/1/edit?output

**Solution**:
Uses replaces to change a single dollar (`$`) to a double dollar (`$$`), so when `content.replace` run we continue with the original `$`.

> From `String#replace` docs:
> $$: Inserts a "$".

Here is my solution (this PR changes): https://jsbin.com/tubuxutado/1/edit?output

_______________
On my production scenario I have a point with `$127,40` dollars exactly on `127,40` tick, and the tooltip value became `27,40`.

Another solution to this is using a double dollar on `tickFormatter`, but I don't know if this is the best solution:
```js
    tickFormatter: function(val, axis) {
      return "$$" + val.toFixed(2);
    }
```