### PR TITLE
Keep tooltip on screen

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -249,6 +249,7 @@
             var totalTipHeight = $tip.outerHeight() + that.tooltipOptions.shifts.y;
             if ((pos.x - $(window).scrollLeft()) > ($(window)[that.wfunc]() - totalTipWidth)) {
                 pos.x -= totalTipWidth;
+                pos.x = Math.max(pos.x, 0);
             }
             if ((pos.y - $(window).scrollTop()) > ($(window)[that.hfunc]() - totalTipHeight)) {
                 pos.y -= totalTipHeight;


### PR DESCRIPTION
This PR keeps tooltip from going off screen to the left (e.g. on narrow mobile screen).
