### PR TITLE
Fix so tooltip will move relative to mouse

### DIFF
--- a/js/jquery.flot.tooltip.js
+++ b/js/jquery.flot.tooltip.js
@@ -299,7 +299,7 @@
                 return;
 
             $tip.html(tipText);
-            plot.setTooltipPosition({ x: position.pageX, y: position.pageY });
+            plot.setTooltipPosition({ x: that.tipPosition.x, y: that.tipPosition.y });
             $tip.css({
                 left: that.tipPosition.x + that.tooltipOptions.shifts.x,
                 top: that.tipPosition.y + that.tooltipOptions.shifts.y


### PR DESCRIPTION
When using bar chart, tooltips only appear at a fix position relative to the bar which lead to bad experience. 

##### *already tested with other examples

Before ![alt text](https://media.giphy.com/media/ooLl9derpsWw8/giphy.gif "gif")

And after: ![alt text](https://media.giphy.com/media/Rk1QpuwEcSivC/giphy.gif)