### PR TITLE
Fix issue when two series have the same x label

### DIFF
--- a/js/jquery.flot.tooltip.source.js
+++ b/js/jquery.flot.tooltip.source.js
@@ -489,14 +489,11 @@
                 ticks = 'ticks';
             }
 
-            // see https://github.com/krzysu/flot.tooltip/issues/65
-            var tickIndex = item.dataIndex + item.seriesIndex;
-
             for (var xIndex in item.series.xaxis[ticks]) {
-                if (item.series.xaxis[ticks].hasOwnProperty(tickIndex) && !this.isTimeMode('xaxis', item)) {
-                    var valueX = (this.isCategoriesMode('xaxis', item)) ? item.series.xaxis[ticks][tickIndex].label : item.series.xaxis[ticks][tickIndex].v;
+                if (item.series.xaxis[ticks].hasOwnProperty(item.dataIndex) && !this.isTimeMode('xaxis', item)) {
+                    var valueX = (this.isCategoriesMode('xaxis', item)) ? item.series.xaxis[ticks][item.dataIndex].label : item.series.xaxis[ticks][item.dataIndex].v;
                     if (valueX === x) {
-                        content = content.replace(xPattern, item.series.xaxis[ticks][tickIndex].label.replace(/\$/g, '$$$$'));
+                        content = content.replace(xPattern, item.series.xaxis[ticks][item.dataIndex].label.replace(/\$/g, '$$$$'));
                     }
                 }
             }


### PR DESCRIPTION
This is fix for #101 the issue appears when fix for #65 was merged.

Fix that was made for #65 is completely incorrect... you should not do that 'cause there will be lot of issues if you have multiple series with the same x label (the tickIndex will be incremented by 1 for each next series). There should be another way to fix #65 